### PR TITLE
Update org.freedesktop.Platform to 22.08

### DIFF
--- a/io.appflowy.AppFlowy.yml
+++ b/io.appflowy.AppFlowy.yml
@@ -1,6 +1,6 @@
 app-id: io.appflowy.AppFlowy
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 command: app_flowy
 separate-locales: false


### PR DESCRIPTION
Potential fix for "GLIBC_2.34 not found" error 