### PR TITLE
Update URL for flathubbot

### DIFF
--- a/io.appflowy.AppFlowy.yml
+++ b/io.appflowy.AppFlowy.yml
@@ -53,7 +53,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 309593
-          url-template: https://github.com/AppFlowy-IO/appflowy/releases/download/$version/AppFlowy_x86_64-unknown-linux-gnu_ubuntu-18.04.tar.gz
+          url-template: https://github.com/AppFlowy-IO/AppFlowy/releases/download/$version/AppFlowy_x86_64-unknown-linux-gnu_ubuntu-20.04.tar.gz
         dest: appflowy
       - type: file
         path: io.appflowy.AppFlowy.desktop


### PR DESCRIPTION
I am not sure how this works, but I guess something like this. So please review my changes first.

Seems like you switched from Ubuntu 18.04 to 20.04 in your build system, so did URLs for release downloads. The URL template have to be changed in the .yml for flathubbot to continue automatic update checks.

I suggest you to remove the whole Ubuntu part from URL altogether so flathubbot could work without issues in the future.