### PR TITLE
Added version 0.1.3 to io.appflowy.AppFlowy.appdata.xml

### DIFF
--- a/io.appflowy.AppFlowy.appdata.xml
+++ b/io.appflowy.AppFlowy.appdata.xml
@@ -46,6 +46,7 @@
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="0.1.4" date="2023-05-04"/>
+    <release version="0.1.3" date="2023-04-24"/>
     <release version="0.1.2" date="2023-03-29"/>
     <release version="0.1.1" date="2023-03-22"/>
     <release version="0.1.0" date="2023-02-09"/>


### PR DESCRIPTION
Isn't all versions should be listed for compatibility (or some other) purposes? If so, this pull request adds missing version 0.1.3 to the manifest