### PR TITLE
chore: bump version 0.5.5

### DIFF
--- a/io.appflowy.AppFlowy.appdata.xml
+++ b/io.appflowy.AppFlowy.appdata.xml
@@ -52,6 +52,7 @@
 		<category>Office</category>
 	</categories>
 	<releases>
+		<release version="0.5.5" date="2024-04-30"/>
 		<release version="0.5.4" date="2024-04-09"/>
 		<release version="0.5.3" date="2024-03-26"/>
 		<release version="0.5.2" date="2024-03-14"/>

--- a/io.appflowy.AppFlowy.yml
+++ b/io.appflowy.AppFlowy.yml
@@ -69,8 +69,8 @@ modules:
       - ln -s /app/appflowy/AppFlowy /app/bin/AppFlowy
     sources:
       - type: archive
-        url: https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.5.4/AppFlowy-0.5.4-linux-x86_64.tar.gz
-        sha256: cb7de7be6eebdb02ce45e536acd1212de1f6a15c47f3e5e91891f1603fc834e5
+        url: https://github.com/AppFlowy-IO/AppFlowy/releases/download/0.5.5/AppFlowy-0.5.5-linux-x86_64.tar.gz
+        sha256: d8ee13d6f1945e8297db4da5c61a8ac436210c5bb266b8ce3f0ba537845938a8
         x-checker-data:
           type: anitya
           project-id: 309593


### PR DESCRIPTION
closes https://github.com/flathub/io.appflowy.AppFlowy/issues/92
