### PR TITLE
Drop libnotify module

### DIFF
--- a/io.appflowy.AppFlowy.yml
+++ b/io.appflowy.AppFlowy.yml
@@ -25,23 +25,6 @@ modules:
         url: https://github.com/kupferlauncher/keybinder/releases/download/keybinder-3.0-v0.3.2/keybinder-3.0-0.3.2.tar.gz
         sha256: e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020
 
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dman=false
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.8.tar.xz
-        sha256: 23420ef619dc2cb5aebad613f4823a2fa41c07e5a1d05628d40f6ec4b35bfddd
-        x-checker-data:
-          type: anitya
-          project-id: 13149
-          url-template: https://download.gnome.org/sources/libnotify/$major.$minor/libnotify-$version.tar.xz
-
   - name: appflowy
     buildsystem: simple
     build-commands:
@@ -53,6 +36,7 @@ modules:
       - install -Dm644 io.appflowy.AppFlowy.desktop /app/share/applications/io.appflowy.AppFlowy.desktop
       - cp -r appflowy/AppFlowy /app/appflowy
       - chmod +x /app/appflowy/AppFlowy
+      - mkdir /app/bin/
       - ln -s /app/appflowy/AppFlowy /app/bin/AppFlowy
     sources:
       - type: archive


### PR DESCRIPTION
Freedesktop runtime version 25.08 already provides the **libnotify** module.

Fixes: https://github.com/flathub/io.appflowy.AppFlowy/issues/196